### PR TITLE
fix(coi): fix coreos-installer-growfs script to support usb installation

### DIFF
--- a/dracut/scripts/coreos-installer-growfs
+++ b/dracut/scripts/coreos-installer-growfs
@@ -4,11 +4,32 @@ set -euo pipefail
 path=/growroot
 udevadm settle
 
-disk=$(lsblk -ln -o NAME,TYPE | grep disk | awk '{print $1}')
-if [[ -z ${disk} ]]; then
-    exit 1
+#Following function takes name as argument e.g. coreos.inst.install_dev and finds its value from
+#cmdline (which is passed at boot time)
+cmdline=( $(</proc/cmdline) )
+karg() {
+    local name="$1" value=""
+    for arg in "${cmdline[@]}"; do
+        if [[ "${arg%%=*}" == "${name}" ]]; then
+            value="${arg#*=}"
+        fi
+    done
+    echo "${value}"
+}
+
+# Get installation device
+installation_device="$(karg coreos.inst.install_dev)"
+if [ "${installation_device##*/}" = "${installation_device}" ]; then
+    # karg contains no slashes.  Prepend "/dev/" for compatibility.
+    installation_device="/dev/${installation_device}"
 fi
-growpart /dev/${disk} 4
+
+#Get number of partitions avaiable for the installation_device and choose last 
+#partition to grow till available disk size.
+device=${installation_device##*/}
+partition=$(grep -c "${device}"[0-9] /proc/partitions)
+growpart $installation_device $partition
+echo "growpart executed on "$installation_device" "$partition" " 
 
 crypt=$(lsblk -ln -o NAME,TYPE | grep crypt | awk '{print $1}')
 if [[ -z ${crypt} ]]; then

--- a/test/edge-simplified-installer.sh
+++ b/test/edge-simplified-installer.sh
@@ -374,10 +374,13 @@ sudo sed -i 's/coreos.inst.image_file=\/run\/media\/iso\/disk.img.xz/coreos.inst
 greenprint "📋 Create libvirt image disk"
 LIBVIRT_IMAGE_PATH=/var/lib/libvirt/images/${IMAGE_KEY}-httpboot.qcow2
 sudo qemu-img create -f qcow2 "${LIBVIRT_IMAGE_PATH}" 20G
+LIBVIRT_FAKE_USB_PATH=/var/lib/libvirt/images/usb.qcow2
+sudo qemu-img create -f qcow2 "${LIBVIRT_FAKE_USB_PATH}" 16G
 
 greenprint "📋 Install edge vm via http boot"
 sudo virt-install --name="${IMAGE_KEY}-httpboot"\
                   --disk path="${LIBVIRT_IMAGE_PATH}",format=qcow2 \
+                  --disk path="${LIBVIRT_FAKE_USB_PATH}",format=qcow2 \
                   --ram 3072 \
                   --vcpus 2 \
                   --network network=integration,mac=34:49:22:B0:83:30 \


### PR DESCRIPTION
This PR contains: 
  - make growpart utility work  on "coreos.inst.install_dev" parameter which is taken from cmdline argument (which is derived from blueprint)rather than lsblk
  - so as to support usb installation case
  - tested manually with and without usb drive.
  - test case will be covered by https://github.com/osbuild/osbuild-composer/pull/3065 
  
Signed-off-by: Sarita Mahajan <sarmahaj@redhat.com>