### PR TITLE
test: update the name of the raw image

### DIFF
--- a/test/edge-simplified-installer.sh
+++ b/test/edge-simplified-installer.sh
@@ -369,7 +369,7 @@ sudo sed -i 's/timeout=60/timeout=10/' "${GRUB_CFG}"
 sudo sed -i 's/coreos.inst.install_dev=\/dev\/sda/coreos.inst.install_dev=\/dev\/vda/' "${GRUB_CFG}"
 sudo sed -i 's/linux \/images\/pxeboot\/vmlinuz/linuxefi \/httpboot\/images\/pxeboot\/vmlinuz/' "${GRUB_CFG}"
 sudo sed -i 's/initrd \/images\/pxeboot\/initrd.img/initrdefi \/httpboot\/images\/pxeboot\/initrd.img/' "${GRUB_CFG}"
-sudo sed -i 's/coreos.inst.image_file=\/run\/media\/iso\/disk.img.xz/coreos.inst.image_url=http:\/\/192.168.100.1\/httpboot\/disk.img.xz/' "${GRUB_CFG}"
+sudo sed -i 's/coreos.inst.image_file=\/run\/media\/iso\/image.raw.xz/coreos.inst.image_url=http:\/\/192.168.100.1\/httpboot\/image.raw.xz/' "${GRUB_CFG}"
 
 greenprint "📋 Create libvirt image disk"
 LIBVIRT_IMAGE_PATH=/var/lib/libvirt/images/${IMAGE_KEY}-httpboot.qcow2


### PR DESCRIPTION
Changes made in osbuild/osbuild-composer#3166 rename the raw image in the ISO from `disk.img.xz` to
`image.raw.xz`, so update the tests that rely on the name of the image.

~~**Note:** this PR is a reminder that the name will change, but we need to follow the PR in the composer to check if the name actually changes or not for this PR to be relevant or not.~~