### PR TITLE
workflow: Do not build osbuild, osbuild-composer if no dependence

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -211,23 +211,29 @@ jobs:
           fetch-depth: 0
           path: coreos-installer-dracut
 
+      # Only run when PR has osbuild dependence
       - name: Checkout osbuild code
+        if: ${{ needs.comment-info.outputs.osbuild_branch != 'main' }}
         uses: actions/checkout@v3
         with:
           repository: ${{ needs.comment-info.outputs.osbuild_repo }}
           ref: ${{ needs.comment-info.outputs.osbuild_branch }}
           path: osbuild
       - name: Build osbuild
+        if: ${{ needs.comment-info.outputs.osbuild_branch != 'main' }}
         run: make rpm
         working-directory: ./osbuild
 
+      # Only run when PR has osbuild-composer dependence
       - name: Checkout osbuild-composer code
+        if: ${{ needs.comment-info.outputs.osbuild-composer_branch != 'main' }}
         uses: actions/checkout@v3
         with:
           repository: ${{ needs.comment-info.outputs.osbuild-composer_repo }}
           ref: ${{ needs.comment-info.outputs.osbuild-composer_branch }}
           path: osbuild-composer
       - name: Build osbuild-composer
+        if: ${{ needs.comment-info.outputs.osbuild-composer_branch != 'main' }}
         run: make rpm
         working-directory: ./osbuild-composer
 


### PR DESCRIPTION
If there's no osbuild or osbuild-composer dependence in PR, building them will not be run. That'll make workflow more efficient.  