### PR TITLE
fix: correctly retrieve the last partition of the installation disk

### DIFF
--- a/dracut/scripts/coreos-installer-growfs
+++ b/dracut/scripts/coreos-installer-growfs
@@ -27,9 +27,9 @@ fi
 #Get number of partitions avaiable for the installation_device and choose last 
 #partition to grow till available disk size.
 device=${installation_device##*/}
-partition=$(grep -c "${device}"[0-9] /proc/partitions)
-growpart $installation_device $partition
-echo "growpart executed on "$installation_device" "$partition" " 
+last_partition="$(ls /sys/block/${device}/*/partition | wc -l)"
+growpart $installation_device $last_partition
+echo "growpart executed on "$installation_device" "$last_partition" "
 
 crypt=$(lsblk -ln -o NAME,TYPE | grep crypt | awk '{print $1}')
 if [[ -z ${crypt} ]]; then


### PR DESCRIPTION
grepping /proc/partitions the way we're doing doesn't account for devices with more numbers according to our grep command. Devices like nvme0n1 would just return "0" as the last partition but that's wrong as what gets executed is:

grep -c nvme0n1[0-9] /proc/partitions

which just returns 0 but it's obviously not the last partition. Fix the above by using the sys filesystem as it provides better heiraical nature of paritions within a drive without accounting for its string format.