### PR TITLE
Replace default.target with initrd.target

### DIFF
--- a/dracut/51coreos-installer/module-setup.sh
+++ b/dracut/51coreos-installer/module-setup.sh
@@ -57,19 +57,19 @@ install() {
         "/usr/libexec/coreos-installer-service"
 
     install_and_enable_unit "coreos-installer.service" \
-        "default.target"
+        "initrd.target"
 
     install_and_enable_unit "coreos-installer-reboot.service" \
-        "default.target"
+        "initrd.target"
 
     install_and_enable_unit "coreos-installer-noreboot.service" \
-        "default.target"
+        "initrd.target"
 
     install_and_enable_unit "coreos-installer-poweroff.service" \
-        "default.target"
+        "initrd.target"
 
     install_and_enable_unit "coreos-installer-growfs.service" \
-        "default.target"
+        "initrd.target"
 
     inst_script "$moddir/coreos-installer-growfs" \
         /usr/libexec/coreos-installer-growfs


### PR DESCRIPTION
`default.target` is not present in c10s, RHEL10, and Fedora 42 initrd so it breaks the initramfs build.

Fixes #40 

See also: https://github.com/coreos/fedora-coreos-config/commit/6b07a63db8590d5a7b2174c614b8b2593b984fa7